### PR TITLE
Using Zustand for state management

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,8 @@
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
     "react-scroll-to-bottom": "^4.1.2",
-    "socket.io-client": "^4.2.0"
+    "socket.io-client": "^4.2.0",
+    "zustand": "^3.6.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^1.0.0",

--- a/client/src/components/Chat.jsx
+++ b/client/src/components/Chat.jsx
@@ -8,6 +8,7 @@ import InfoBar from './InfoBar';
 import Input from './Input';
 import Messages from './Messages';
 import Navbar from './Navbar';
+import Roommates from './Roommates';
 
 let socket;
 
@@ -34,9 +35,7 @@ const Chat = ({ location }) => {
     });
 
     return () => {
-      resetStore();
-
-      socket.emit('disconnect');
+      socket.emit('leave');
       socket.off();
     };
   }, [ENDPOINT, location.search]);
@@ -57,12 +56,31 @@ const Chat = ({ location }) => {
   };
 
   return (
-    <div>
+    <div className="w-screen h-screen bg-green-50">
       <Navbar />
-      <div className="flex flex-col items-center pt-16 bg-green-50 h-screen w-screen pt-32 overflow-y-hidden">
-        <InfoBar room={room} name={name} />
-        <Messages messages={messages} name={name} />
-        <Input message={message} setMessage={setMessage} sendMessage={sendMessage} />
+      <div
+        className="w-screen h-full flex items-center justify-center
+        overflow-hidden"
+      >
+        <div
+          className="relative top-12
+          flex flex-col items-center
+          h-5/6 w-5/6
+          shadow-xl
+          overflow-hidden
+          rounded-xl"
+        >
+          <InfoBar room={room} name={name} />
+          <div className="grid grid-cols-5 w-full h-full">
+            <div className="col-span-4 flex flex-col border-r-2 border-blue-50">
+              <Messages messages={messages} name={name} />
+              <Input message={message} setMessage={setMessage} sendMessage={sendMessage} />
+            </div>
+            <div className="col-span-1 bg-white">
+              <Roommates />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/InfoBar.jsx
+++ b/client/src/components/InfoBar.jsx
@@ -51,7 +51,7 @@ const InfoBar = ({ room, name }) => {
       </div>
       {showCloseModal && (
         <Modal
-          data={{ header: 'You are about to exist the chat room' }}
+          data={{ header: 'You are about to exit the chat room' }}
           actions={{
             onCancel: () => setShowCloseModal(false),
             onConfirm: () => history.push('/'),

--- a/client/src/components/InfoBar.jsx
+++ b/client/src/components/InfoBar.jsx
@@ -4,6 +4,7 @@ import { useHistory } from 'react-router-dom';
 import closeIcon from '../assets/icons/closeIcon.png';
 import onlineIcon from '../assets/icons/onlineIcon.png';
 import { requestPermission } from '../utils/notification';
+import useStore from '../utils/store';
 import { Modal } from './atoms/Modal';
 import { NotificationBar } from './atoms/Notification';
 import { ShareButton } from './Share';
@@ -12,6 +13,7 @@ const InfoBar = ({ room, name }) => {
   const history = useHistory();
   const [showPermissionMsg, setShowPermissionMsg] = useState(false);
   const [showCloseModal, setShowCloseModal] = useState(false);
+  const resetStore = useStore((state) => state.resetStore);
 
   useEffect(() => {
     const timeout = setTimeout(() => {
@@ -34,10 +36,15 @@ const InfoBar = ({ room, name }) => {
           }}
         />
       ) : null}
-      <div className="flex justify-between items-center w-5/6 md:w-4/6 lg:w-3/6 bg-white rounded-t-xl p-4 shadow-t-3xl pt-6 border-b-2 border-blue-50">
+      <div
+        className="flex justify-between items-center
+        w-full overflow-y-hidden
+        bg-white rounded-t-xl p-4 pl-2
+        border-b-2 border-blue-50"
+      >
         <div className="flex items-center">
           <img src={onlineIcon} alt="online" className="h-3 ml-5 place-self-center" />
-          <h3 className="ml-1 place-self-center">{room}</h3>
+          <h3 className="mx-2 place-self-center text-lg text-gray-600 font-semibold">{room}</h3>
           <ShareButton
             link={`${window.location.origin}/#/?room=${room}`}
             text={`Hey! ${name} invites you to join ${room} Chat Room on Chatcus`}
@@ -54,7 +61,10 @@ const InfoBar = ({ room, name }) => {
           data={{ header: 'You are about to exit the chat room' }}
           actions={{
             onCancel: () => setShowCloseModal(false),
-            onConfirm: () => history.push('/'),
+            onConfirm: () => {
+              resetStore();
+              history.push('/');
+            },
           }}
         />
       )}

--- a/client/src/components/Input.jsx
+++ b/client/src/components/Input.jsx
@@ -5,7 +5,7 @@ import sendIcon from '../assets/icons/sendIcon-green.png';
 const Input = ({ message, setMessage, sendMessage }) => {
   return (
     <form
-      className="flex justify-between items-center bg-white rounded-b-xl shadow-xl w-5/6 md:w-4/6 lg:w-3/6 lg:w-3/6 border-t-4 border-blue-50"
+      className="flex justify-between items-center bg-white shadow-xl w-full border-t-4 border-blue-50 h-16"
       onSubmit={(e) => {
         e.preventDefault();
         console.log(`Your message: ${message}`);
@@ -19,10 +19,10 @@ const Input = ({ message, setMessage, sendMessage }) => {
         value={message}
         onChange={(event) => setMessage(event.target.value)}
         placeholder="Type a message..."
-        className="p-4 w-full outline-none rounded-bl-xl text-gray-800"
+        className="w-full h-full px-4 outline-none text-gray-600 font-medium"
       />
-      <button type="submit" className="p-4 rounded-br-xl hover:bg-green-100 transition duration-150 ease-in">
-        <img src={sendIcon} className="px-2 w-12 place-self-center" alt="Send Message" />
+      <button type="submit" className="px-6 h-full hover:bg-green-100 transition duration-150 ease-in">
+        <img src={sendIcon} className="w-8 h-8 place-self-center" alt="Send Message" />
       </button>
     </form>
   );

--- a/client/src/components/Join.jsx
+++ b/client/src/components/Join.jsx
@@ -15,6 +15,8 @@ const Join = ({ location, history }) => {
   const [errors, setErrors] = useState({ name: '', room: '' });
   useEffect(() => {
     store.resetStore();
+
+    const { room } = queryString.parse(location.search);
     if (room) {
       setRoom(room);
     }

--- a/client/src/components/Join.jsx
+++ b/client/src/components/Join.jsx
@@ -14,8 +14,7 @@ const Join = ({ location, history }) => {
 
   const [errors, setErrors] = useState({ name: '', room: '' });
   useEffect(() => {
-    const { room } = queryString.parse(location.search);
-    console.log(queryString.parse(location.search));
+    store.resetStore();
     if (room) {
       setRoom(room);
     }

--- a/client/src/components/Join.jsx
+++ b/client/src/components/Join.jsx
@@ -1,5 +1,6 @@
 import queryString from 'query-string';
 import React, { useEffect, useState } from 'react';
+import useStore from '../utils/store';
 
 import { TextField } from './atoms/TextField';
 import Navbar from './Navbar';
@@ -8,6 +9,9 @@ const Join = ({ location, history }) => {
   const [name, setName] = useState('');
   const [room, setRoom] = useState('');
   const [pfpSrc, setPfpSrc] = useState('');
+
+  const store = useStore((state) => state);
+
   const [errors, setErrors] = useState({ name: '', room: '' });
   useEffect(() => {
     const { room } = queryString.parse(location.search);
@@ -60,7 +64,13 @@ const Join = ({ location, history }) => {
               setErrors(err);
               return event.preventDefault();
             }
-            history.push(`/chat?name=${name}&room=${room}&pfp=${pfpSrc}`);
+
+            // Set state in store
+            store.setName(name);
+            store.setRoom(room);
+            store.setPfpSrc(pfpSrc || `https://robohash.org/${name.split(' ').join('-')}?set=set4`);
+
+            history.push(`/chat`);
           }}
           className="bg-green-700 text-white mt-4 sm:text-sm md:text-lg p-4 rounded-md hover:bg-green-900"
           type="button"

--- a/client/src/components/Message.jsx
+++ b/client/src/components/Message.jsx
@@ -25,13 +25,7 @@ const Message = ({ message: { user, text, pfpSrc }, name }) => {
         </div>
       </div>
       <div className="col-start-6 col-end-7 text-center">
-        <img
-          className="inline object-cover w-14 h-14 rounded-full"
-          src={
-            pfpSrc || "https://cdn-icons-png.flaticon.com/512/709/709722.png"
-          }
-          alt={`Profile image-${user}`}
-        />
+        <img className="inline object-cover w-14 h-14 rounded-full" src={pfpSrc} alt={`Profile image-${user}`} />
         <br />
       </div>
     </motion.div>
@@ -54,13 +48,7 @@ const Message = ({ message: { user, text, pfpSrc }, name }) => {
       className="grid grid-cols-6"
     >
       <div className="col-start-1 col-end-2 text-center">
-        <img
-          className="inline object-cover w-14 h-14 rounded-full"
-          src={
-            pfpSrc || "https://cdn-icons-png.flaticon.com/512/709/709722.png"
-          }
-          alt="Profile image"
-        />
+        <img className="inline object-cover w-14 h-14 rounded-full" src={pfpSrc} alt="Profile image" />
         <br />
       </div>
       <div className="col-start-2 col-end-7">

--- a/client/src/components/Message.jsx
+++ b/client/src/components/Message.jsx
@@ -16,15 +16,15 @@ const Message = ({ message: { user, text, pfpSrc }, name }) => {
     <motion.div
       initial={{ scale: 0, x: '70%', opacity: 0.3 }}
       animate={{ scale: 1, x: 0, opacity: 1 }}
-      className="grid grid-cols-6"
+      className="flex gap-3 items-center px-3"
     >
-      <div className="col-start-1 col-end-6">
+      <div className="flex-grow">
         <div className="flex flex-col ml-auto p-2 rounded-t-xl rounded-l-xl bg-green-100 shadow-md m-2 w-max max-w-xs lg:max-w-lg overflow-hidden">
           <p className="text-green-900 text-sm font-semibold">{trimmedName}</p>
           <p className="pr-2 text-gray-600">{text}</p>
         </div>
       </div>
-      <div className="col-start-6 col-end-7 text-center">
+      <div className="flex-shrink">
         <img className="inline object-cover w-14 h-14 rounded-full" src={pfpSrc} alt={`Profile image-${user}`} />
         <br />
       </div>
@@ -45,13 +45,13 @@ const Message = ({ message: { user, text, pfpSrc }, name }) => {
     <motion.div
       initial={{ scale: 0, x: '-70%', opacity: 0.3 }}
       animate={{ scale: 1, x: 0, opacity: 1 }}
-      className="grid grid-cols-6"
+      className="flex gap-3 items-center px-3"
     >
-      <div className="col-start-1 col-end-2 text-center">
+      <div className="flex-shrink">
         <img className="inline object-cover w-14 h-14 rounded-full" src={pfpSrc} alt="Profile image" />
         <br />
       </div>
-      <div className="col-start-2 col-end-7">
+      <div className="flex-grow">
         <div className="flex flex-col items-start p-2 rounded-t-xl rounded-r-xl w-max max-w-xs bg-green-500 shadow-md text-white m-2 overflow-hidden lg:max-w-lg">
           <p className="text-sm font-semibold">{user}</p>
           <p className="pr-2">{text}</p>

--- a/client/src/components/Messages.jsx
+++ b/client/src/components/Messages.jsx
@@ -6,7 +6,7 @@ import ScrollToBottom from 'react-scroll-to-bottom';
 import Message from './Message';
 
 const Messages = ({ messages, name }) => (
-  <ScrollToBottom className="overflow-auto w-5/6 md:w-4/6 lg:w-3/6 p-4 h-4/6 bg-white text-sm md:text-lg">
+  <ScrollToBottom className="overflow-auto flex-grow w-full p-4 bg-white text-sm md:text-lg">
     {messages.map((message, i) => (
       <Message message={message} name={name} key={`${message.user}-${i}`} />
     ))}

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -10,7 +10,7 @@ const Navbar = () => {
         className="flex items-center rounded-md border-green-700 border-2 p-2 hover:text-black hover:bg-green-50"
       >
         <img src="https://ik.imagekit.io/manuelalferez/chatcus/github_7y-K8IT6TGe.svg?updatedAt=1634803536227" />
-        <spam className="pl-2">GitHub</spam>
+        <span className="pl-2">GitHub</span>
       </a>
     </div>
   );

--- a/client/src/components/Roommates.jsx
+++ b/client/src/components/Roommates.jsx
@@ -1,0 +1,48 @@
+import { motion } from 'framer-motion';
+import * as React from 'react';
+import useStore from '../utils/store';
+
+const Roommates = () => {
+  const roommates = useStore((state) => state.roommates);
+  const currentUsername = useStore((state) => state.name);
+
+  return (
+    <div className="flex flex-col pb-2">
+      <div className="w-full px-3 py-2 bg-white text-green-800 font-medium text-sm">Participants: {roommates.length}</div>
+      {roommates &&
+        roommates.map((roommate) => (
+          <RoommateName
+            name={roommate.name === currentUsername ? `${roommate.name} (You)` : roommate.name}
+            pfpSrc={roommate.pfpSrc}
+            key={roommate.name}
+          />
+        ))}
+    </div>
+  );
+};
+
+const RoommateName = ({ name, pfpSrc }) => {
+  return (
+    <motion.div
+      className="grid grid-cols-5 items-center
+      px-3 py-2
+      bg-white hover:bg-green-100 cursor-pointer
+      transition-all duration-150 ease-out"
+      initial={{
+        opacity: 0,
+        x: '100%',
+      }}
+      animate={{
+        opacity: 1,
+        x: 0,
+      }}
+    >
+      <div className="col-span-1 flex">
+        <img className="w-8 h-8 rounded-full border-2 border-green-200" src={pfpSrc} alt={name} />
+      </div>
+      <div className="col-span-4 font-semibold text-gray-500">{name}</div>
+    </motion.div>
+  );
+};
+
+export default Roommates;

--- a/client/src/utils/notification.js
+++ b/client/src/utils/notification.js
@@ -11,6 +11,7 @@ export const showNotification = (message) => {
     try {
       const notification = new Notification(`${message.user?.toUpperCase()} just send a message`, {
         body: message.text,
+        icon: message.pfpSrc,
       });
       notification.onclick = () => {
         window.parent.focus();

--- a/client/src/utils/store.js
+++ b/client/src/utils/store.js
@@ -1,23 +1,31 @@
 import create from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { devtools, persist } from 'zustand/middleware';
 
 const useStore = create(
-  devtools((set) => ({
-    name: '',
-    room: '',
-    pfpSrc: '',
-    roommates: [],
-    messages: [],
+  devtools(
+    persist(
+      (set) => ({
+        name: '',
+        room: '',
+        pfpSrc: '',
+        roommates: [],
+        messages: [],
 
-    setName: (name) => set({ name }),
-    setRoom: (room) => set({ room }),
-    setPfpSrc: (pfpSrc) => set({ pfpSrc }),
+        setName: (name) => set({ name }),
+        setRoom: (room) => set({ room }),
+        setPfpSrc: (pfpSrc) => set({ pfpSrc }),
 
-    setRoommates: (roommates) => set((state) => ({ roommates })),
-    addMessage: (message) => set((state) => ({ messages: [...state.messages, message] })),
+        setRoommates: (roommates) => set((state) => ({ roommates })),
+        addMessage: (message) => set((state) => ({ messages: [...state.messages, message] })),
 
-    resetStore: () => set((state) => ({ name: '', room: '', pfpSrc: '', roommates: [], messages: [] })),
-  })),
+        resetStore: () => set((state) => ({ name: '', room: '', pfpSrc: '', roommates: [], messages: [] })),
+      }),
+      {
+        name: 'chatcus-storage',
+        getStorage: () => sessionStorage,
+      },
+    ),
+  ),
 );
 
 export default useStore;

--- a/client/src/utils/store.js
+++ b/client/src/utils/store.js
@@ -1,0 +1,23 @@
+import create from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+const useStore = create(
+  devtools((set) => ({
+    name: '',
+    room: '',
+    pfpSrc: '',
+    roommates: [],
+    messages: [],
+
+    setName: (name) => set({ name }),
+    setRoom: (room) => set({ room }),
+    setPfpSrc: (pfpSrc) => set({ pfpSrc }),
+
+    setRoommates: (roommates) => set((state) => ({ roommates })),
+    addMessage: (message) => set((state) => ({ messages: [...state.messages, message] })),
+
+    resetStore: () => set((state) => ({ name: '', room: '', pfpSrc: '', roommates: [], messages: [] })),
+  })),
+);
+
+export default useStore;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -47,7 +47,8 @@ io.on("connection", (socket) => {
     });
     callback();
   });
-  socket.on("disconnect", () => {
+
+  const leaveRoom = () => {
     const user = removeUser(socket.id);
     if (user) {
       io.to(user.room).emit("message", {
@@ -56,7 +57,11 @@ io.on("connection", (socket) => {
         roommates: getUsersInRoom(user.room),
       });
     }
-  });
+  };
+
+  socket.on("leave", leaveRoom);
+
+  socket.on("disconnect", leaveRoom);
 });
 
 app.use(router);

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -21,15 +21,20 @@ io.on("connection", (socket) => {
       return callback(error);
     }
 
+    const roommates = getUsersInRoom(user.room);
+
     socket.join(user.room);
     socket.emit("message", {
       user: "admin",
       text: `${user.name} welcome to the room ${user.room}`,
+      roommates,
     });
 
-    socket.broadcast
-      .to(user.room)
-      .emit("message", { user: "admin", text: `${user.name} has joined!` });
+    socket.broadcast.to(user.room).emit("message", {
+      user: "admin",
+      text: `${user.name} has joined!`,
+      roommates,
+    });
     callback();
   });
 
@@ -48,6 +53,7 @@ io.on("connection", (socket) => {
       io.to(user.room).emit("message", {
         user: "admin",
         text: `${user.name} has left`,
+        roommates: getUsersInRoom(user.room),
       });
     }
   });


### PR DESCRIPTION
# Added Zustand state management

This pull reques includes the addition of state management for the app using [Zustand](https://github.com/pmndrs/zustand/). Changes introduced are:
- No need to pass username, room name and profile pic in the chat page URL
- Manage **roommates** in state
- Includes sender profile pic in notification
- Manages **messages** in state

### Note
> Persistent state may be added later, if required, which would enable the user to view the messages even after reloading the chats page
>
> :warning: This PR includes changes to **server code**. Please REDEPLOY to Heroku


## Roommates list :people_holding_hands: :people_holding_hands: 
The list of roommates is stored in the Zustand store and can be accessed by
```js
import useStore from "../utils/store";

// ... Inside component
const roommates = useStore(state => state.roommates);
```
### Uses
:bulb: Using the list of roommates, a new component can be created which would display all the users in the current room. The roommates list comes from the server's `server/src/users.js`: `getUsersInRoom(room)` function. So the format of each roommate in the list is of the form
```
{
  id: <socket id>,
  name: <user name>,
  room: <room name>,
  pfpSrc: <profile pic URL>
}
```

Also, in each `admin` type message from the server, the roommate list is passed and set in the client's store.

## Auto Profile pic :cat: 
If no profile pic URL is specified, a cute kitty profile pic is automatically assigned to the user using `https://robohash.org/<username>?set=set4`